### PR TITLE
fix repo URLs in integration's manifest

### DIFF
--- a/custom_components/kingsmith_walkingpad/manifest.json
+++ b/custom_components/kingsmith_walkingpad/manifest.json
@@ -2,8 +2,8 @@
   "domain": "kingsmith_walkingpad",
   "name": "KingSmith WalkingPad",
   "config_flow": true,
-  "documentation": "https://github.com/UrbanTechIO/kingsmith_walkingpad",
-  "issue_tracker": "https://github.com/UrbanTechIO/kingsmith_walkingpad/issues",
+  "documentation": "https://github.com/UrbanTechIO/KingSmith-WalkingPad",
+  "issue_tracker": "https://github.com/UrbanTechIO/KingSmith-WalkingPad/issues",
   "requirements": [
     "bleak>=0.21.0",
     "bleak-retry-connector>=3.0.0"


### PR DESCRIPTION
This fixes little issue here:
<img width="1586" height="793" alt="image" src="https://github.com/user-attachments/assets/124db369-cddd-4f6f-80ae-f51f14c78e1e" />
